### PR TITLE
- fix for Grails2 versions >= 2.4.4.

### DIFF
--- a/FilmStripGrailsPlugin.groovy
+++ b/FilmStripGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 class FilmStripGrailsPlugin {
-    def version = "0.1.6"
+    def version = "0.1.7"
     def grailsVersion = "2.1 > *"
     def pluginExcludes = [
         "README.adoc",

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -186,10 +186,10 @@ def createFilmStrip= {
 
 eventTestSuiteStart = { typeName ->
     println "FilmStrip eventTestSuiteStart: $typeName"
-    inFunctionalTestPhase = (typeName == 'functional')
+    inFunctionalTestPhase = (typeName in ['functional', 'spock'])
     if (!inFunctionalTestPhase) return
 
-    println "FilmStrip: monkey patch for geb.report.Reporter"
+    println "FilmStrip: monkey patch for geb.report.ReporterSupport"
     ReporterSupport.metaClass.static.toTestReportLabel={
         int testCounter,
         int reportCounter,


### PR DESCRIPTION
 TestSuite typeName can be „spock“.